### PR TITLE
feat: Add local loading state support

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,29 @@ function Avatar() {
 }
 ```
 
+## Local Loading State
+
+Sometimes you want a loading state that is tied to the lifecycle of a component
+(just like useState).
+`useCreateLocalLoading` creates a loading instance that is automatically destroyed when the component unmounts.
+
+```javascript
+import { useCreateLocalLoading } from 'react-easy-loading';
+
+function MyComponent() {
+  const loading = useCreateLocalLoading();
+  
+  // Use it just like a regular loading instance
+  const isLoading = loading.useIsLoading();
+
+  return (
+    <div>
+      {isLoading ? 'Loading...' : 'Done'}
+    </div>
+  );
+}
+```
+
 ## ✨ Automatic State Management with `wrap`
 
 The `wrap` function automates state management.
@@ -269,14 +292,15 @@ Use these to get the current value without subscribing to updates.
 
 Use these to control the state from anywhere.
 
-| Method              | Description                                |
-|---------------------|--------------------------------------------|
-| `set(state)`        | Manually sets the loading state.           |
-| `reset()`           | Resets the state to its initial value.     |
-| `retry()`           | Re-runs the last wrapped async function.   |
-| `setRetry(fn)`      | Manually provides a custom retry function. |
-| `setErrors(errors)` | Overwrites the errors array.               |
-| `addError(error)`   | Adds an error to the errors array.         |
+| Method              | Description                                         |
+|---------------------|-----------------------------------------------------|
+| `set(state)`        | Manually sets the loading state.                    |
+| `reset()`           | Resets the state to its initial value.              |
+| `retry()`           | Re-runs the last wrapped async function.            |
+| `setRetry(fn)`      | Manually provides a custom retry function.          |
+| `setErrors(errors)` | Overwrites the errors array.                        |
+| `addError(error)`   | Adds an error to the errors array.                  |
+| `destroy()`         | Destroys the loading instance and clears its state. |
 
 ---
 

--- a/demo/app.tsx
+++ b/demo/app.tsx
@@ -3,9 +3,9 @@ import {
     createLoading,
     type LoadingState,
     registerDefaultFallback,
-    registerFallback
+    registerFallback, useCreateLocalLoading
 } from 'react-easy-loading';
-import {useState} from "react";
+import {useEffect, useState} from "react";
 import {expose} from "react-exposed-states";
 import {useEffectSkipFirst} from "use-effect-skip-first";
 
@@ -62,6 +62,42 @@ const Component = () => {
     )
 }
 
+const Component2Wrapper = () => {
+    const [yes, setYes] = useState(false);
+
+    const handle = () => {
+        setYes(v => !v);
+    }
+
+    return (
+        <div>
+            <p>local one wrapper</p>
+            <button onClick={handle}>Show</button>
+            {yes ? <Component2/> : "NONE"}
+        </div>
+    )
+}
+
+const Component2 = () => {
+    const loading = useCreateLocalLoading();
+    const l = loading.use();
+
+    const handle = async () => {
+        loading.set(loading.get() === "loading" ? "success" : "loading");
+    }
+
+    useEffect(() => {
+        console.log("l", l, loading.__get__id());
+    }, [l]);
+
+    return (
+        <div>
+            <p>local one {l}</p>
+            <button onClick={handle}>Click me</button>
+        </div>
+    )
+}
+
 const App = () => {
 
 
@@ -70,6 +106,7 @@ const App = () => {
         <div>
             <h1 className="text-red-600">React Easy Loading Demo</h1>
             <Component/>
+            <Component2Wrapper/>
 
             <userLoading.ShowWhenFinish>
                 <h3>DONE</h3>

--- a/src/create-loading.tsx
+++ b/src/create-loading.tsx
@@ -70,6 +70,14 @@ export type Loading<Errors extends unknown[] = string[], Context extends Record<
         children?: ReactNodeOrFunction<[errors: Errors | undefined, retry: (() => void) | undefined]> | undefined;
     }>;
     ShowWhen: React.FC<PropsWithChildren<{ state: LoadingState }>>;
+    destroy: () => void;
+    /**
+     * @internal THIS IS USED FOR INTERNAL PURPOSES ONLY,
+     * DON'T USE IT,
+     * DON'T RELY ON IT,
+     * DON'T REPORT ANY ISSUE RELATED TO IT
+     */
+    __get__id: () => string;
 }
 
 export type CreateLoadingOptions = {
@@ -268,6 +276,18 @@ export const createLoading = <Errors extends unknown[] = string[], Context exten
             const Component = showWhenFactory(state);
             return <Component>{children}</Component>
         },
+        destroy: () => {
+            sharedStatesApi.clear(sharedState)
+        },
+        /**
+         * @internal THIS IS USED FOR INTERNAL PURPOSES ONLY,
+         * DON'T USE IT,
+         * DON'T RELY ON IT,
+         * DON'T REPORT ANY ISSUE RELATED TO IT
+         */
+        __get__id: () => {
+            return `loading_id//${sharedState.prefix}/${sharedState.key}`
+        }
     }
 
     return loading;

--- a/src/create-local-loading.tsx
+++ b/src/create-local-loading.tsx
@@ -1,0 +1,14 @@
+import {createLoading, type CreateLoadingOptions, type Loading} from "./create-loading";
+import {useEffect, useRef} from "react";
+
+export const useCreateLocalLoading = <Errors extends unknown[] = string[], Context extends Record<string, unknown> = any>(createLoadingOptions: CreateLoadingOptions = {}): Loading<Errors, Context> => {
+    const loading = useRef(createLoading<Errors, Context>(createLoadingOptions));
+
+    useEffect(() => {
+        return () => {
+            loading.current.destroy()
+        }
+    }, []);
+
+    return loading.current;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './fallbacks';
 export * from './create-loading';
+export * from './create-local-loading';
 export * from './components';

--- a/tests/create-local-loading.test.tsx
+++ b/tests/create-local-loading.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest';
+import { useCreateLocalLoading } from '../src';
+import { renderHook } from '@testing-library/react';
+
+describe('useCreateLocalLoading', () => {
+    it('should create a loading instance', () => {
+        const { result } = renderHook(() => useCreateLocalLoading());
+        expect(result.current).toBeDefined();
+        expect(result.current.get()).toBe('loading'); // Default is loading
+    });
+
+    it('should destroy the loading instance on unmount', () => {
+        const { result, unmount } = renderHook(() => useCreateLocalLoading());
+        const loading = result.current;
+        
+        const destroySpy = vi.spyOn(loading, 'destroy');
+        
+        unmount();
+        
+        expect(destroySpy).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Description
This PR introduces `useCreateLocalLoading`, a hook that creates a loading state tied to a component's lifecycle (like useState). The state is automatically destroyed when the component unmounts.

## Changes
*   Added `useCreateLocalLoading` hook.
*   Added `destroy()` method to loading instances to handle cleanup.
*   Included unit tests and updated documentation.